### PR TITLE
Update tsconfig.json

### DIFF
--- a/app/src/tsconfig.json
+++ b/app/src/tsconfig.json
@@ -31,7 +31,7 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    "typeRoots": ["./src/types"] /* Specify multiple folders that act like './node_modules/@types'. */,
+    "typeRoots": ["./node_modules/@types", "./types"] /* Specify multiple folders that act like './node_modules/@types'. */,
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */


### PR DESCRIPTION
- いざNode.js使ったツール作ろうとした段階で、@types/nodeの補間が効いてないことを確認、修正。
- typeRootsの設定についてオレオレ型を参照するパスも間違ってる。修正。。